### PR TITLE
Add deny effect to the root policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ data "aws_iam_policy_document" "deny_root_account" {
   statement {
     actions   = ["*"]
     resources = ["*"]
+    effect    = "Deny"
     condition {
       test     = "StringLike"
       variable = "aws:PrincipalArn"


### PR DESCRIPTION
Missed the effect attribute to the deny-root policy. I tested the change, and this appears to work. 