### PR TITLE
Adding restrict regions SCP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary:505a1f49f0f81e331e16f2f4e59fdba3258f9423
+      - image: trussworks/circleci-docker-primary:c542b22c7fb95db0a1bbe043928a457ae6fbeaca
     steps:
       - checkout
       - restore_cache:

--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ module "org_scps" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+
 ## Providers
 
 | Name | Version |
@@ -106,7 +112,8 @@ module "org_scps" {
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
+| allowed\_regions | AWS Regions allowed for use (for use with the restrict regions SCP) | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
 | deny\_all\_access\_target\_ids | Target ids (AWS Account or Organizational Unit) to attach an SCP dening all access | `list(string)` | `[]` | no |
 | deny\_creating\_iam\_users\_target\_ids | Target ids (AWS Account or Organizational Unit) to attach an SCP denying the ability to create IAM users or Access Keys | `list(string)` | `[]` | no |
 | deny\_deleting\_cloudwatch\_logs\_target\_ids | Target ids (AWS Account or Organizational Unit) to attach an SCP denying deletion of CloudWatch, flowlogs,  log groups, or log streams | `list(string)` | `[]` | no |
@@ -119,6 +126,7 @@ module "org_scps" {
 | protect\_s3\_bucket\_resources | S3 bucket resource ARNs to protect from bucket and object deletion | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
 | protect\_s3\_bucket\_target\_ids | Target ids (AWS Account or Organizational Unit) to attach an SCP protecting S3 buckets and objects | `list(string)` | `[]` | no |
 | require\_s3\_encryption\_target\_ids | Target ids (AWS Account or Organizational Unit) to attach an SCP requiring S3 encryption | `list(string)` | `[]` | no |
+| restrict\_regions\_target\_ids | Target ids (AWS Account or Organizational Unit) to attach an SCP restricting regions. | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -69,3 +69,15 @@ variable "protect_iam_role_resources" {
   type        = list(string)
   default     = [""]
 }
+
+variable "restrict_regions_target_ids" {
+  description = "Target ids (AWS Account or Organizational Unit) to attach an SCP restricting regions."
+  type        = list(string)
+  default     = []
+}
+
+variable "allowed_regions" {
+  description = "AWS Regions allowed for use (for use with the restrict regions SCP)"
+  type        = list(string)
+  default     = [""]
+}


### PR DESCRIPTION
This adds a new SCP that restricts AWS operations which are not a specific subset of region-agnostic services from being performed in regions not in an allowed list of regions.

I was trying to decide if I wanted to name the `allowed_regions` variable something like `restrict_allowed_regions` so that it would appear next to the other variable I added, but that sounded too much like a boolean variable, I thought.