### PR TITLE
Adding a null element to the protect iam role target list

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ module "org_scps" {
 | deny\_leaving\_orgs\_target\_ids | Target ids (AWS Account or Organizational Unit) to attach an SCP denying the ability to leave the AWS Organization | `list(string)` | `[]` | no |
 | deny\_root\_account\_target\_ids | Target ids (AWS Account or Organizational Unit) to attach an SCP denying the root user from taking any action | `list(string)` | `[]` | no |
 | protect\_iam\_role\_resources | IAM role resource ARNs to protect from modification and deletion | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
-| protect\_iam\_role\_target\_ids | Target ids (AWS Account or Organizational Unit) to attach an SCP protecting IAM roles | `list(string)` | `[]` | no |
+| protect\_iam\_role\_target\_ids | Target ids (AWS Account or Organizational Unit) to attach an SCP protecting IAM roles | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
 | protect\_s3\_bucket\_resources | S3 bucket resource ARNs to protect from bucket and object deletion | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
 | protect\_s3\_bucket\_target\_ids | Target ids (AWS Account or Organizational Unit) to attach an SCP protecting S3 buckets and objects | `list(string)` | `[]` | no |
 | require\_s3\_encryption\_target\_ids | Target ids (AWS Account or Organizational Unit) to attach an SCP requiring S3 encryption | `list(string)` | `[]` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -61,7 +61,7 @@ variable "protect_s3_bucket_resources" {
 variable "protect_iam_role_target_ids" {
   description = "Target ids (AWS Account or Organizational Unit) to attach an SCP protecting IAM roles"
   type        = list(string)
-  default     = []
+  default     = [""]
 }
 
 variable "protect_iam_role_resources" {


### PR DESCRIPTION
This fixes the error caused by having an empty list introduced in v1.5.0. This just adds a null string element to the default list, so if there's nothing added to this parameter it can still create the SCP with a valid list of targets. I've tested this by planning using this version of the module in the GovCloud org and didn't get the error we were seeing yesterday.