### PR TITLE
Real fix for the protect-iam-roles issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ module "org_scps" {
 | deny\_deleting\_route53\_zones\_target\_ids | Target ids (AWS Account or Organizational Unit) to attach an SCP denying deleting Route53 Hosted Zones | `list(string)` | `[]` | no |
 | deny\_leaving\_orgs\_target\_ids | Target ids (AWS Account or Organizational Unit) to attach an SCP denying the ability to leave the AWS Organization | `list(string)` | `[]` | no |
 | deny\_root\_account\_target\_ids | Target ids (AWS Account or Organizational Unit) to attach an SCP denying the root user from taking any action | `list(string)` | `[]` | no |
-| protect\_iam\_role\_resources | IAM role resource ARNs to protect from modification and deletion | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
+| protect\_iam\_role\_resources | IAM role resource ARNs to protect from modification and deletion | `list(string)` | `[]` | no |
 | protect\_iam\_role\_target\_ids | Target ids (AWS Account or Organizational Unit) to attach an SCP protecting IAM roles | `list(string)` | `[]` | no |
 | protect\_s3\_bucket\_resources | S3 bucket resource ARNs to protect from bucket and object deletion | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
 | protect\_s3\_bucket\_target\_ids | Target ids (AWS Account or Organizational Unit) to attach an SCP protecting S3 buckets and objects | `list(string)` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ module "org_scps" {
 | deny\_leaving\_orgs\_target\_ids | Target ids (AWS Account or Organizational Unit) to attach an SCP denying the ability to leave the AWS Organization | `list(string)` | `[]` | no |
 | deny\_root\_account\_target\_ids | Target ids (AWS Account or Organizational Unit) to attach an SCP denying the root user from taking any action | `list(string)` | `[]` | no |
 | protect\_iam\_role\_resources | IAM role resource ARNs to protect from modification and deletion | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
-| protect\_iam\_role\_target\_ids | Target ids (AWS Account or Organizational Unit) to attach an SCP protecting IAM roles | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
+| protect\_iam\_role\_target\_ids | Target ids (AWS Account or Organizational Unit) to attach an SCP protecting IAM roles | `list(string)` | `[]` | no |
 | protect\_s3\_bucket\_resources | S3 bucket resource ARNs to protect from bucket and object deletion | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
 | protect\_s3\_bucket\_target\_ids | Target ids (AWS Account or Organizational Unit) to attach an SCP protecting S3 buckets and objects | `list(string)` | `[]` | no |
 | require\_s3\_encryption\_target\_ids | Target ids (AWS Account or Organizational Unit) to attach an SCP requiring S3 encryption | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -286,15 +286,17 @@ data "aws_iam_policy_document" "protect_iam_roles" {
 }
 
 resource "aws_organizations_policy" "protect_iam_roles" {
+  count = var.protect_iam_role_resources != [""] ? 1 : 0
+
   name        = "protect-iam-roles"
   description = "Protect IAM roles from modification or deletion"
   content     = data.aws_iam_policy_document.protect_iam_roles.json
 }
 
 resource "aws_organizations_policy_attachment" "protect_iam_roles" {
-  count = length(var.protect_iam_role_target_ids)
+  count = var.protect_iam_role_resources != [""] ? length(var.protect_iam_role_target_ids) : 0
 
-  policy_id = aws_organizations_policy.protect_iam_roles.id
+  policy_id = aws_organizations_policy.protect_iam_roles[0].id
   target_id = element(var.protect_iam_role_target_ids.*, count.index)
 }
 

--- a/main.tf
+++ b/main.tf
@@ -267,7 +267,7 @@ resource "aws_organizations_policy_attachment" "protect_s3_buckets" {
 #
 
 data "aws_iam_policy_document" "protect_iam_roles" {
-  count = var.protect_iam_role_resources != [""] ? 1 : 0
+  count = length(var.protect_iam_role_resources) != 0 ? 1 : 0
 
   statement {
     effect = "Deny"
@@ -288,7 +288,7 @@ data "aws_iam_policy_document" "protect_iam_roles" {
 }
 
 resource "aws_organizations_policy" "protect_iam_roles" {
-  count = var.protect_iam_role_resources != [""] ? 1 : 0
+  count = length(var.protect_iam_role_resources) != 0 ? 1 : 0
 
   name        = "protect-iam-roles"
   description = "Protect IAM roles from modification or deletion"

--- a/main.tf
+++ b/main.tf
@@ -267,6 +267,8 @@ resource "aws_organizations_policy_attachment" "protect_s3_buckets" {
 #
 
 data "aws_iam_policy_document" "protect_iam_roles" {
+  count = var.protect_iam_role_resources != [""] ? 1 : 0
+
   statement {
     effect = "Deny"
     actions = [
@@ -290,7 +292,7 @@ resource "aws_organizations_policy" "protect_iam_roles" {
 
   name        = "protect-iam-roles"
   description = "Protect IAM roles from modification or deletion"
-  content     = data.aws_iam_policy_document.protect_iam_roles.json
+  content     = data.aws_iam_policy_document.protect_iam_roles[0].json
 }
 
 resource "aws_organizations_policy_attachment" "protect_iam_roles" {

--- a/variables.tf
+++ b/variables.tf
@@ -61,7 +61,7 @@ variable "protect_s3_bucket_resources" {
 variable "protect_iam_role_target_ids" {
   description = "Target ids (AWS Account or Organizational Unit) to attach an SCP protecting IAM roles"
   type        = list(string)
-  default     = [""]
+  default     = []
 }
 
 variable "protect_iam_role_resources" {

--- a/variables.tf
+++ b/variables.tf
@@ -67,7 +67,7 @@ variable "protect_iam_role_target_ids" {
 variable "protect_iam_role_resources" {
   description = "IAM role resource ARNs to protect from modification and deletion"
   type        = list(string)
-  default     = [""]
+  default     = []
 }
 
 variable "restrict_regions_target_ids" {


### PR DESCRIPTION
Okay, my previous easy fix didn't actually work because the policy document we were creating was invalid. In order to fix it, I had to basically add switches on everything to see if the parameters were empty. This reverts the previous change as well, and changes the default for the other variable to be an empty list to make some of the logic a little easier.

I've tested this with an apply of the git SHA against both `trussworks-gov-org-root` and `trussworks-org-root`, so I'm *sure* this actually works correctly with both cases now.